### PR TITLE
Updating podspec and tag

### DIFF
--- a/FRY.podspec
+++ b/FRY.podspec
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 Pod::Spec.new do |s|
   s.name         = "FRY"
-  s.version      = "0.3"
+  s.version      = "0.4"
   s.summary      = "An iOS integration library."
 
   s.description  = <<-DESC
@@ -12,7 +12,7 @@ Pod::Spec.new do |s|
   s.license      = { :type => "MIT", :file => "LICENSE" }
   s.author       = { "Brian King" => "brianaking@gmail.com" }
   s.platform     = :ios, 7.0
-  s.source       = { :git => "https://github.com/Raizlabs/FRY.git", :tag => "0.3" }
+  s.source       = { :git => "https://github.com/Raizlabs/FRY.git", :tag => "0.4" }
 
   s.source_files  = "FRY", "FRY/**/*.{h,m}"
   s.public_header_files = "FRY/**/*.h"


### PR DESCRIPTION
We're in the process of trying out some UI Testing frameworks and I remembered this one from a RaizLabs talk a while back.  Seems cool so far, but I had to update the podspec before I could try it.

I updated the podspec so I could host it in a personal repo until this is completed.  My main problem is that features of the example project aren't available in the current pod.  Most notably `FRYTouchRecorder.h`.  I'm not sure if tags will transfer in a PR, so if they don't, you'll need to add a `0.4` tag personally.
